### PR TITLE
chore: Atualizando a forma de definir a saída do comando

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Extrair versão da tag
         id: extract_version
-        run: echo "::set-output name=version::${GITHUB_REF/refs\/tags\//}"
+        run: echo "version=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
 
       - name: Build e push
         uses: docker/build-push-action@v5


### PR DESCRIPTION
O `::set-output` está obsoleto, então esse PR atualiza o workflow para utilizar a prática recomendada.

Fonte: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ 